### PR TITLE
Updated fonts throughout the page to use 'Poppins' loaded via Google CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-This is a starter template for [Learn Next.js](https://nextjs.org/learn).
+This is the code for my homepage at https://lancejeffers.com
+
+Lovingly crafted with React, TypeScript, and Next.js I decided to leave it publicly viewable in case anyone was curious about how I approached constructing my portfolio. Many of the interesting CSS effects on my page were copied from other developers before me (who probably copied it from other developers before them), so I figured I would "pay it forward" by keeping the code for this portfolio public.
+
+While I certainly don't mind you borrowing ideas or seeing how I implemented certain features, I do ask that you don't actually copy large sections of the website -- I'd suggest creating your own website from scratch since it helps you reinforce coding concepts, and simply use this code as a reference for certain pieces.
+
+Testing is done using Jest (shout out to Kent Dodds for his TestingJavaScript course). Website is deployed to AWS. Always happy to nerd out on any technologies used in this app.

--- a/components/SkillsSection/SkillsSection.jsx
+++ b/components/SkillsSection/SkillsSection.jsx
@@ -7,12 +7,12 @@ import { WorkTime } from './workTime.svg';
 
 const Section = styled.section`
   width: 80%;
-  margin: 0 auto 6rem auto;
+  margin: 6rem auto;
   text-align: center;
 
   h2 {
     color: ${(props) => props.theme.colorPrimary};
-    font-size: ${(props) => props.theme.fontXL};
+    font-size: ${(props) => props.theme.fontXXL};
   }
 
   .footer-svg {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,12 @@ const Main = styled.main`
 export default function Home({ allPostsData }) {
   return (
     <>
-      <Head>…</Head>
+      <Head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <NavBar />
       <Main>
         {/* <Layout home> */}

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -8,8 +8,7 @@ html,
 body {
   padding: 3rem 0 0 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu,
-    Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: 'Poppins', sans-serif;
   background-color: $color-x-light;
 }
 

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -9,10 +9,13 @@ const Theme = {
   // ALTERNATIVE PRIMARY: #0070f3,
   colorLight: '#44cfcb',
   colorExtraLight: '#EBE9E9',
+  gradientPrimary:
+    'linear-gradient(146deg, #058ED9 40%, #44CFCB 100%) no-repeat 50% 50% / 100% 100%',
 
   /**
    * FONT SIZES
    */
+  fontXXL: '4.5rem',
   fontXL: '3.5rem',
   fontLarge: '3rem',
   fontMedium: '2rem',

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -3,3 +3,6 @@ $color-dark: #2a4494;
 $color-primary: #058ed9;
 $color-light: #44cfcb;
 $color-x-light: #ebe9e9;
+
+$gradient-primary: linear-gradient(146deg, #058ed9 40%, #44cfcb 100%) no-repeat 50% 50% /
+  100% 100%;


### PR DESCRIPTION
## Description:
Default fonts on the page looked bland -- definitely needed something with a bit more personality.

## Changes I Made:
* Loaded 'Poppins' font via Google CDN
* Added a gradient color that can be used throughout the app, but chose not to utilize it yet.
* Updated README.md file to no longer reference the default Next.js readme

## How to Test:
1. `npm run dev` and check out the h1-h6 tags as well as the paragraph tags.
2. README.md is publicly viewable in the repo.

## Dev checklist
- [x] I have reviewed my own work
- [x] I have reviewed relevant browser/server logs
- [  ] I have written appropriate tests
- [x] I have checked-in only the relevant files
- [  ] I have added only appropriate documentation
- [x] I have run my code